### PR TITLE
Add basic DM fitting residuals plot

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -53,6 +53,7 @@ The images names and descriptions are listed below in the same order they appear
 - `{cleaned/raw}_SNR_cumulative.png`: The cumulative signal-to-noise ratio plot which shows how the SNR increases with time.
 - `{cleaned/raw}_SNR_single.png`: The single subint signal-to-noise ratio plot which shows the SNR at each subint.
 - `cleaned_rmfit.png`: The result of the `rmfit` command for checking the quality of the RM measurement.
+- `cleaned_dmfit.png`: The TEMPO2 DM-fitting residual output plot.
 
 ### Decimated
 

--- a/modules/local/dm_rm_calc.nf
+++ b/modules/local/dm_rm_calc.nf
@@ -15,7 +15,7 @@ process DM_RM_CALC {
     tuple val(meta), path(ephemeris), path(template), path(raw_archive), path(cleaned_archive)
 
     output:
-    tuple val(meta), path(ephemeris), path(template), path(raw_archive), path(cleaned_archive), path("${meta.pulsar}_${meta.utc}_dm_rm_fit.json"), path("{cleaned,no}_rmfit.png")
+    tuple val(meta), path(ephemeris), path(template), path(raw_archive), path(cleaned_archive), path("${meta.pulsar}_${meta.utc}_dm_rm_fit.json"), path("{cleaned,no}_rmfit.png"), path("{cleaned,no}_dmfit.png")
 
     when:
     task.ext.when == null || task.ext.when
@@ -41,6 +41,7 @@ process DM_RM_CALC {
         }
         EOF
         touch no_rmfit.png
+        touch no_dmfit.png
         """
     else if ( Float.valueOf(meta.snr) > 20.0 )
         """
@@ -73,7 +74,8 @@ process DM_RM_CALC {
         sed -i '/-snr 0 /d' dm.tim
         # Fit for DM
         tempo2 -nofit -fit DM -set START 40000 -set FINISH 99999 -f ${ephemeris}.dm -outpar ${ephemeris}.dmfit dm.tim
-
+        # Plot DM fit residuals as a function of frequency
+        tempo2 -gr plk  -nofit -set START 40000 -set FINISH 99999 -f ${ephemeris}.dmfit  dm.tim -yplot 2 -xplot 7 -grdev cleaned_dmfit.png/png -publish -us       
         input_rm=\$(vap -c rm ${meta.pulsar}_${meta.utc}_zap.rmcalc | tail -n 1| tr -s ' ' | cut -d ' ' -f 2)
         if [ "${meta.band}" == "UHF" ]; then
             rm_range=7
@@ -160,6 +162,7 @@ process DM_RM_CALC {
         }
         EOF
         touch no_rmfit.png
+        touch no_dmfit.png
         """
 
     stub:
@@ -178,5 +181,6 @@ process DM_RM_CALC {
     }
     EOF
     touch no_rmfit.png
+    touch no_dmfit.png
     """
 }

--- a/modules/local/generate_image_results.nf
+++ b/modules/local/generate_image_results.nf
@@ -17,7 +17,7 @@ process GENERATE_IMAGE_RESULTS {
         'nickswainston/meerpipe:3.0.6' }"
 
     input:
-    tuple val(meta), path(ephemeris), path(template), path(raw_archive), path(cleaned_archive), path(dm_results), path(rm_fit_image)
+    tuple val(meta), path(ephemeris), path(template), path(raw_archive), path(cleaned_archive), path(dm_results), path(rm_fit_image), path(dm_fit_image)
 
     output:
     tuple val(meta), path("*.png", includeInputs: true), path("*.dat"), path("*dynspec"), path("results.json")

--- a/modules/local/generate_image_results.nf
+++ b/modules/local/generate_image_results.nf
@@ -42,7 +42,7 @@ process GENERATE_IMAGE_RESULTS {
         psrplot -p Scyl -jFTD  -jC                          -g 1024x768 -c above:l= -c above:c="Polarisation Profile (\${type})" -D \${type}_profile_ftp.png/png \$file
         psrplot -p freq -jTDp  -jC                          -g 1024x768 -c above:l= -c above:c="Phase vs. Frequency (\${type})"  -D \${type}_phase_freq.png/png  \$file
         psrplot -p time -jFDp  -jC                          -g 1024x768 -c above:l= -c above:c="Phase vs. Time (\${type})"       -D \${type}_phase_time.png/png  \$file
-        psrplot -p b -x -jT -lpol=0,1 -O -c log=1 -c skip=1 -g 1024x768 -c above:l= -c above:c="Cleaned bandpass (\${type})"     -D \${type}_bandpass.png/png    \$file
+        psrplot -p b -x -jT -lpol=0,1 -O -c log=1 -c skip=1 -g 1024x768 -c above:l= -c above:c="Bandpass (\${type})"     -D \${type}_bandpass.png/png    \$file
     done
 
     # Create flux and polarisation scrunched archive for SNR images

--- a/modules/local/upload_dm_rm_results.nf
+++ b/modules/local/upload_dm_rm_results.nf
@@ -59,6 +59,8 @@ process UPLOAD_DM_RM_RESULTS {
     image_data = []
     if os.path.exists("cleaned_rmfit.png"):
         image_data.append( ("cleaned_rmfit.png", 'rmfit', 'high', True ) )
+    if os.path.exists("cleaned_dmfit.png"):
+        image_data.append( ("cleaned_dmfit.png", 'dmfit', 'high', True ) )
 
     # Upload images
     for image_path, image_type, resolution, cleaned in image_data:

--- a/modules/local/upload_results.nf
+++ b/modules/local/upload_results.nf
@@ -83,6 +83,8 @@ process UPLOAD_RESULTS {
             image_data.append( ("${meta.pulsar}_${meta.utc}_zap.ar.dynspec.png", 'dynamic-spectrum', 'high', True ) )
         if os.path.exists("cleaned_rmfit.png"):
             image_data.append( ("cleaned_rmfit.png", 'rmfit', 'high', True ) )
+        if os.path.exists("cleaned_dmfit.png"):
+            image_data.append( ("cleaned_dmfit.png", 'dmfit', 'high', True ) )
 
     # Upload images
     for image_path, image_type, resolution, cleaned in image_data:

--- a/nextflow.config
+++ b/nextflow.config
@@ -196,7 +196,7 @@ if ( hostname.startsWith("tooarrana") || hostname.startsWith("trevor") ) {
             maxRetries = 2
         }
         withLabel: database_upload {
-            maxForks = 3
+            maxForks = 8
             errorStrategy = 'retry'
             maxRetries = 2
         }


### PR DESCRIPTION
This is a pretty basic added output plot that shows the residuals of the DM fit per radio frequency bin. A more sophisticated plot is planned. I've based these changes on [this similar commit ](https://github.com/nf-core/meerpipe/commit/a03255e7d96afb102ac0312d779abf7e2cb7b08e). I have tested this meerpipe in nextflow on a small batch of data and it made plots in the right place. I did not try a database upload.
If this looks OK and is merged I will add the corresponding changes on the meertime dataportal repo.