### PR TITLE
Added refold option

### DIFF
--- a/modules/local/generate_image_results.nf
+++ b/modules/local/generate_image_results.nf
@@ -32,12 +32,23 @@ process GENERATE_IMAGE_RESULTS {
     # psrplot images
     raw_archive=${raw_archive}
     cleaned_archive=${cleaned_archive}
-    type_file_array=(${ template.baseName == "no_template" ? '"raw ${raw_archive}"' : '"raw ${raw_archive}" "cleaned ${cleaned_archive}"' })
+
+    # Determine type_file_array based on conditions
+    type_file_array=()
+    if [ "${params.refold_prev_ar}" == "true" ]; then
+        type_file_array+=("cleaned ${cleaned_archive}")
+    elif [ "${template.baseName}" == "no_template" ]; then
+        type_file_array+=("raw ${raw_archive}")
+    else
+        type_file_array+=("raw ${raw_archive}" "cleaned ${cleaned_archive}")
+    fi
+
     for i in "\${type_file_array[@]}"; do
+        echo "Plotting: \$i" 
         set -- \$i
         type=\$1
         file=\$2
-        # Do the plots for raw file then cleaned file
+        echo "Type: \$type, File: \$file"
         psrplot -p flux -jFTDp -jC                          -g 1024x768 -c above:l= -c above:c="Stokes I Profile (\${type})"     -D \${type}_profile_fts.png/png \$file
         psrplot -p Scyl -jFTD  -jC                          -g 1024x768 -c above:l= -c above:c="Polarisation Profile (\${type})" -D \${type}_profile_ftp.png/png \$file
         psrplot -p freq -jTDp  -jC                          -g 1024x768 -c above:l= -c above:c="Phase vs. Frequency (\${type})"  -D \${type}_phase_freq.png/png  \$file
@@ -45,8 +56,10 @@ process GENERATE_IMAGE_RESULTS {
         psrplot -p b -x -jT -lpol=0,1 -O -c log=1 -c skip=1 -g 1024x768 -c above:l= -c above:c="Bandpass (\${type})"     -D \${type}_bandpass.png/png    \$file
     done
 
-    # Create flux and polarisation scrunched archive for SNR images
-    pam -Fp -e rawFp ${raw_archive}
+    if [ "${params.refold_prev_ar}" == "false" ]; then
+        # Create flux and polarisation scrunched archive for SNR images
+        pam -Fp -e rawFp ${raw_archive}
+    fi
     if [ "${template.baseName}" != "no_template" ]; then
         pam -Fp -e cleanFp ${cleaned_archive}
         # Create a frequency, time and polarisation scrunched file for flux calc
@@ -62,11 +75,15 @@ process GENERATE_IMAGE_RESULTS {
             pam -b \$((std_nbin / obs_nbin)) -e new_std ${template}
             std_template=*new_std
         fi
-        psrflux -s \${std_template} -e dynspec ${raw_archive}
+        if [ "${params.refold_prev_ar}" == "false" ]; then
+            psrflux -s \${std_template} -e dynspec ${raw_archive}
+        fi
         psrflux -s \${std_template} -e dynspec ${cleaned_archive}
     fi
 
     # Create matplotlib images and dump the results calculations into a results.json file
+    # The raw_Fp option is not used in the OzGrav/meerpipe generate_images_results script if refold_prev_ar is true
+    # Same thing for cleanFp and cleanFTp if raw_only is true
     generate_images_results \\
         --pid ${meta.project_short} \\
         --raw_file ${raw_archive} \\
@@ -80,7 +97,8 @@ process GENERATE_IMAGE_RESULTS {
         --snr ${meta.snr} \\
         --flux ${meta.flux} \\
         --dm_file ${dm_results} \\
-        ${ template.baseName == "no_template" ? "--raw_only" : "" }
+        ${ template.baseName == "no_template" ? "--raw_only" : "" } \\
+        ${ params.refold_prev_ar ? "--cleaned_only" : "" }
     """
 
     stub:

--- a/modules/local/obs_list.nf
+++ b/modules/local/obs_list.nf
@@ -37,6 +37,7 @@ process OBS_LIST {
     import shutil
     import logging
     import pandas as pd
+    import glob
     from datetime import datetime
 
     from psrdb.tables.observation import Observation
@@ -272,14 +273,36 @@ process OBS_LIST {
         # Count observations with the same pulsar
         obs_df.at[index, 'n_obs']     = len(obs_df[obs_df['Pulsar Jname'] == pulsar])
 
+        print(f"Checking for existence of file ${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}/{obs['UTC Start']}_raw.ar")
+        if glob.glob(f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_raw.ar") == []:
+            with open('empty_raw.ar', 'w'):
+                pass # Make an empty file
+            obs_df['raw_archive'] = os.path.join(os.getcwd(), 'empty_raw.ar')
+        else:
+            #This will happen if the pipeline has been run with no template before and therefore there is only a raw archive available.
+            obs_df['raw_archive'] = f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_raw.ar"
+        
+        if "${params.refold_prev_ar}" == "true" or "${params.use_prev_ar}" == "true":
+            print(f"Checking for existence of file ${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}/{obs['UTC Start']}_zap.ar")
+            if glob.glob(f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_zap.ar") == []:
+                raise FileNotFoundError(f"File ${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_zap.ar not found, and cannot be used or refolded. Stopping the pipeline.")
+        
+        if "${params.refold_prev_ar}" == "false" and "${params.use_prev_ar}" == "false":
+            with open('empty_clean.ar', 'w'):
+                pass # Make an empty file
+            obs_df['cleaned_archive'] = os.path.join(os.getcwd(), 'empty_clean.ar')
+        
+            obs_df = obs_df[[
+            "Obs ID", "Pulsar Jname", "UTC Start", "Project Short Name", "Beam #", "Observing Band",
+            "Duration (s)", "Mode Duration (s)", "Nchan", "Nbin", "Calibration Location",
+            "pipe_id", "ephemeris", "template", "n_obs", "raw_archive", "cleaned_archive"]]
+        
+
     if "${params.use_prev_ar}" == "true":
         obs_df['sn'] = 0.
         obs_df['flux'] = 0.
         obs_df['percent_rfi_zapped'] = 0.
-        with open('empty_raw.ar', 'w'):
-            pass # Make an empty file
-        obs_df['raw_archive'] = os.path.join(os.getcwd(), 'empty_raw.ar')
-        obs_df['clean_archive'] = ''
+        obs_df['cleaned_archive'] = ''
         for index, obs in obs_df.iterrows():
             pfr_data = pfr_client.list(
                 pulsar=obs["Pulsar Jname"],
@@ -291,7 +314,38 @@ process OBS_LIST {
             obs_df.at[index, 'sn'] = pfr_data[0]['pipelineRun']['sn']
             obs_df.at[index, 'flux'] = pfr_data[0]['pipelineRun']['flux']
             obs_df.at[index, 'percent_rfi_zapped'] = pfr_data[0]['pipelineRun']['percentRfiZapped']
-            obs_df.at[index, 'clean_archive'] = f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_zap.ar"
+            obs_df.at[index, 'cleaned_archive'] = f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_zap.ar"
+            #Explicitely set the order of the columns so that they are read correctly by meerpipe.nf
+        obs_df = obs_df[[
+        "Obs ID", "Pulsar Jname", "UTC Start", "Project Short Name", "Beam #", "Observing Band",
+        "Duration (s)", "Mode Duration (s)", "Nchan", "Nbin", "Calibration Location",
+        "pipe_id", "ephemeris", "template", "n_obs", "sn", "flux", "percent_rfi_zapped",
+        "raw_archive", "cleaned_archive"]]
+
+    if "${params.refold_prev_ar}" == "true":
+        obs_df['percent_rfi_zapped'] = 0.
+        obs_df['cleaned_archive'] = ''
+        for index, obs in obs_df.iterrows():
+            pfr_data = pfr_client.list(
+                pulsar=obs["Pulsar Jname"],
+                mainProject="MeerTIME",
+                utcStart=obs["UTC Start"],
+                beam=obs["Beam #"],
+            )
+            print(pfr_data)
+            obs_df.at[index, 'percent_rfi_zapped'] = pfr_data[0]['pipelineRun']['percentRfiZapped'] 
+            obs_df.at[index, 'cleaned_archive'] = f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_zap.ar"
+
+        obs_df = obs_df[[
+        "Obs ID", "Pulsar Jname", "UTC Start", "Project Short Name", "Beam #", "Observing Band",
+        "Duration (s)", "Mode Duration (s)", "Nchan", "Nbin", "Calibration Location",
+        "pipe_id", "ephemeris", "template", "n_obs", "percent_rfi_zapped",
+        "raw_archive", "cleaned_archive"]]
+    
+
+        
+    
+
 
     # Write out results
     obs_df.drop('Obs ID', axis=1, inplace=True)

--- a/modules/local/obs_list.nf
+++ b/modules/local/obs_list.nf
@@ -273,25 +273,27 @@ process OBS_LIST {
         # Count observations with the same pulsar
         obs_df.at[index, 'n_obs']     = len(obs_df[obs_df['Pulsar Jname'] == pulsar])
 
-        print(f"Checking for existence of file ${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}/{obs['UTC Start']}_raw.ar")
-        if glob.glob(f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_raw.ar") == []:
+        raw_archive_path =  f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_raw.ar"
+        print(f"Checking for existence of file {raw_archive_path}")
+        if glob.glob(raw_archive_path) == []:
             with open('empty_raw.ar', 'w'):
                 pass # Make an empty file
             obs_df['raw_archive'] = os.path.join(os.getcwd(), 'empty_raw.ar')
         else:
             #This will happen if the pipeline has been run with no template before and therefore there is only a raw archive available.
-            obs_df['raw_archive'] = f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_raw.ar"
+            obs_df['raw_archive'] = raw_archive_path
         
+        cleaned_archive_path = f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_zap.ar"
         if "${params.refold_prev_ar}" == "true" or "${params.use_prev_ar}" == "true":
-            print(f"Checking for existence of file ${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}/{obs['UTC Start']}_zap.ar")
-            if glob.glob(f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_zap.ar") == []:
-                raise FileNotFoundError(f"File ${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_zap.ar not found, and cannot be used or refolded. Stopping the pipeline.")
+            print(f"Checking for existence of file {cleaned_archive_path}")
+            if glob.glob(cleaned_archive_path) == []:
+                raise FileNotFoundError(f"File {cleaned_archive_path} not found, and cannot be used or refolded. Stopping the pipeline.")
         
         if "${params.refold_prev_ar}" == "false" and "${params.use_prev_ar}" == "false":
             with open('empty_clean.ar', 'w'):
                 pass # Make an empty file
             obs_df['cleaned_archive'] = os.path.join(os.getcwd(), 'empty_clean.ar')
-        
+            #Explicitely set the order of the columns so that they are read correctly by meerpipe.nf
             obs_df = obs_df[[
             "Obs ID", "Pulsar Jname", "UTC Start", "Project Short Name", "Beam #", "Observing Band",
             "Duration (s)", "Mode Duration (s)", "Nchan", "Nbin", "Calibration Location",
@@ -315,7 +317,7 @@ process OBS_LIST {
             obs_df.at[index, 'flux'] = pfr_data[0]['pipelineRun']['flux']
             obs_df.at[index, 'percent_rfi_zapped'] = pfr_data[0]['pipelineRun']['percentRfiZapped']
             obs_df.at[index, 'cleaned_archive'] = f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_zap.ar"
-            #Explicitely set the order of the columns so that they are read correctly by meerpipe.nf
+        #Explicitely set the order of the columns so that they are read correctly by meerpipe.nf
         obs_df = obs_df[[
         "Obs ID", "Pulsar Jname", "UTC Start", "Project Short Name", "Beam #", "Observing Band",
         "Duration (s)", "Mode Duration (s)", "Nchan", "Nbin", "Calibration Location",
@@ -335,7 +337,7 @@ process OBS_LIST {
             print(pfr_data)
             obs_df.at[index, 'percent_rfi_zapped'] = pfr_data[0]['pipelineRun']['percentRfiZapped'] 
             obs_df.at[index, 'cleaned_archive'] = f"${params.outdir}/{obs['Pulsar Jname']}/{obs['UTC Start']}/{obs['Beam #']}/{obs['Pulsar Jname']}_{obs['UTC Start']}_zap.ar"
-
+        #Explicitely set the order of the columns so that they are read correctly by meerpipe.nf
         obs_df = obs_df[[
         "Obs ID", "Pulsar Jname", "UTC Start", "Project Short Name", "Beam #", "Observing Band",
         "Duration (s)", "Mode Duration (s)", "Nchan", "Nbin", "Calibration Location",

--- a/modules/local/psradd_calibrate_clean.nf
+++ b/modules/local/psradd_calibrate_clean.nf
@@ -173,6 +173,7 @@ process PSRADD_CALIBRATE_CLEAN {
 
         if [ "\${normalised_cleaned_archive}" != "\${normalised_expected_archive}" ]; then
             mv "${cleaned_archive}" "${meta.pulsar}_${meta.utc}_zap.ar"
+            echo "New cleaned archive has not got the same name as the old cleaned archive (\${normalised_cleaned_archive} != \${normalised_expected_archive}) but replacing old archive with new archive
         fi
 
         pam -FTp -e FTp ${meta.pulsar}_${meta.utc}_zap.ar

--- a/modules/local/psradd_calibrate_clean.nf
+++ b/modules/local/psradd_calibrate_clean.nf
@@ -15,11 +15,12 @@ process PSRADD_CALIBRATE_CLEAN {
         'nickswainston/meerpipe:latest' }"
 
     input:
-    tuple val(meta), path(cal_loc), path(ephemeris), path(template)
-
+    tuple val(meta), path(cal_loc), path(ephemeris), path(template), path(raw_archive), path(cleaned_archive) 
+    //raw archive input is not used here
+    //it's empty_raw.ar normally, except in the case where the pipeline was run without a template and thus created a raw archive only
     output:
-    tuple val(meta), path(ephemeris), path(template), path("${meta.pulsar}_${meta.utc}_raw.ar"), path("${meta.pulsar}_${meta.utc}_zap.ar"), env(SNR), env(FLUX)
-
+    tuple val(meta), path(ephemeris), path(template), path("${meta.pulsar}_${meta.utc}_{raw,raw_empty}.ar"), path("${meta.pulsar}_${meta.utc}_zap.ar"), env(SNR), env(FLUX)
+    //IF refold_prev_ar is true a raw archive will not be recreated thus we will create an empty file
     when:
     task.ext.when == null || task.ext.when
 
@@ -32,124 +33,148 @@ process PSRADD_CALIBRATE_CLEAN {
     """
     raw_only=${ template.baseName == "no_template" ? "true" : "false" }
 
-    # Grab obs.header to output it the publishDir
-    mkdir -p ${params.outdir}/${meta.pulsar}/${meta.utc}/${meta.beam}
-    cp ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/obs.header ${params.outdir}/${meta.pulsar}/${meta.utc}/${meta.beam}
+    if [ "${params.refold_prev_ar}" == "false" ]; then
 
-    if ${params.use_edge_subints}; then
-        # Grab all archives
-        archives=\$(ls ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/*.ar)
-    else
-        if [ -z \$(ls ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/*.ar | head -n-1 | tail -n+2) ]; then
-            # Grab all archives anyway because there are only two
+
+        # Grab obs.header to output it the publishDir
+        mkdir -p ${params.outdir}/${meta.pulsar}/${meta.utc}/${meta.beam}
+        cp ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/obs.header ${params.outdir}/${meta.pulsar}/${meta.utc}/${meta.beam}
+
+        if ${params.use_edge_subints}; then
+            # Grab all archives
             archives=\$(ls ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/*.ar)
         else
-            # Grab all archives except for the first and last one
-            archives=\$(ls ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/*.ar | head -n-1 | tail -n+2)
+            if [ -z \$(ls ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/*.ar | head -n-1 | tail -n+2) ]; then
+                # Grab all archives anyway because there are only two
+                archives=\$(ls ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/*.ar)
+            else
+                # Grab all archives except for the first and last one
+                archives=\$(ls ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/*.ar | head -n-1 | tail -n+2)
+            fi
         fi
-    fi
 
-    if [ "\$raw_only" == "false" ]; then
-        echo "Check if you need to change the template bins"
-        obs_nbin=\$(vap -c nbin \$(echo "\$archives" | awk '{print \$1}') | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2)
-        std_nbin=\$(vap -c nbin ${template} | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2)
-        if [ "\$obs_nbin" == "\$std_nbin" ]; then
-            std_template=${template}
+        if [ "\$raw_only" == "false" ]; then
+            echo "Check if you need to change the template bins"
+            obs_nbin=\$(vap -c nbin \$(echo "\$archives" | awk '{print \$1}') | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2)
+            std_nbin=\$(vap -c nbin ${template} | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2)
+            if [ "\$obs_nbin" == "\$std_nbin" ]; then
+                std_template=${template}
+            else
+                echo "Making a new template with right number of bins"
+                pam -b \$((std_nbin / obs_nbin)) -e new_std ${template}
+                std_template=*new_std
+            fi
+        fi
+
+        echo "Combine the archives"
+        psradd \\
+            -E ${ephemeris} \\
+            -o ${meta.pulsar}_${meta.utc}_raw.ar \\
+            \${archives}
+        if [ "\$raw_only" == "false" ]; then
+            echo "Clean the archive"
+            clean_archive.py \\
+                -a ${meta.pulsar}_${meta.utc}_raw.ar \\
+                -T \${std_template} \\
+                -o ${meta.pulsar}_${meta.utc}_zap.ar
+        fi
+
+
+        echo "Calibrate the polarisation of the archive"
+        if [[ "${cal_loc}" == "" || "${cal_loc}" == "no_cal_file" ]]; then
+            # The archives have already be calibrated so just update the headers
+            pac_args="-XP -e scalP"
         else
-            echo "Making a new template with right number of bins"
-            pam -b \$((std_nbin / obs_nbin)) -e new_std ${template}
-            std_template=*new_std
+            # Use the Stokes paramaters files to calibrate the archive
+            cal_loc="${cal_loc}"
+            pac_args="-Q \${cal_loc//\\\\/} -e scal"
         fi
-    fi
+        pac \${pac_args} -O ./ ${meta.pulsar}_${meta.utc}_raw.ar
+        if [ "\$raw_only" == "false" ]; then
+            pac \${pac_args} -O ./ ${meta.pulsar}_${meta.utc}_zap.ar
+        fi
 
-    echo "Combine the archives"
-    psradd \\
-        -E ${ephemeris} \\
-        -o ${meta.pulsar}_${meta.utc}_raw.ar \\
-        \${archives}
-    if [ "\$raw_only" == "false" ]; then
-        echo "Clean the archive"
-        clean_archive.py \\
-            -a ${meta.pulsar}_${meta.utc}_raw.ar \\
-            -T \${std_template} \\
-            -o ${meta.pulsar}_${meta.utc}_zap.ar
-    fi
+        echo "Update the DM header value from ephemeris"
+        pam --update_dm -E ${ephemeris} -m ${meta.pulsar}_${meta.utc}_raw.scalP
+        if [ "\$raw_only" == "false" ]; then
+            pam --update_dm -E ${ephemeris} -m ${meta.pulsar}_${meta.utc}_zap.scalP
+        fi
 
-
-    echo "Calibrate the polarisation of the archive"
-    if [[ "${cal_loc}" == "" || "${cal_loc}" == "no_cal_file" ]]; then
-        # The archives have already be calibrated so just update the headers
-        pac_args="-XP -e scalP"
-    else
-        # Use the Stokes paramaters files to calibrate the archive
-        cal_loc="${cal_loc}"
-        pac_args="-Q \${cal_loc//\\\\/} -e scal"
-    fi
-    pac \${pac_args} -O ./ ${meta.pulsar}_${meta.utc}_raw.ar
-    if [ "\$raw_only" == "false" ]; then
-        pac \${pac_args} -O ./ ${meta.pulsar}_${meta.utc}_zap.ar
-    fi
-
-    echo "Update the DM header value from ephemeris"
-    pam --update_dm -E ${ephemeris} -m ${meta.pulsar}_${meta.utc}_raw.scalP
-    if [ "\$raw_only" == "false" ]; then
-        pam --update_dm -E ${ephemeris} -m ${meta.pulsar}_${meta.utc}_zap.scalP
-    fi
-
-    echo "Update the RM value if available"
-    rm_cat=\$(python -c "from meerpipe.data_load import RM_CAT;print(RM_CAT)")
-    if grep -q "${meta.pulsar}" \${rm_cat}; then
-        rm=\$(grep ${meta.pulsar} \${rm_cat} | tr -s ' ' | cut -d ' ' -f 2)
-        echo "Found RM of \${rm} in the private RM catalogue"
-    else
-        rm=\$(psrcat -c RM ${meta.pulsar} -X | tr -s ' ' | cut -d ' ' -f 1)
-        if [[ "\${rm}" == "*" || "\${rm}" == "WARNING:" ]]; then
-            echo "No RM found in the ATNF catalogue"
-            rm=0
+        echo "Update the RM value if available"
+        rm_cat=\$(python -c "from meerpipe.data_load import RM_CAT;print(RM_CAT)")
+        if grep -q "${meta.pulsar}" \${rm_cat}; then
+            rm=\$(grep ${meta.pulsar} \${rm_cat} | tr -s ' ' | cut -d ' ' -f 2)
+            echo "Found RM of \${rm} in the private RM catalogue"
         else
-            echo "Found RM of \${rm} in the ATNF catalogue"
+            rm=\$(psrcat -c RM ${meta.pulsar} -X | tr -s ' ' | cut -d ' ' -f 1)
+            if [[ "\${rm}" == "*" || "\${rm}" == "WARNING:" ]]; then
+                echo "No RM found in the ATNF catalogue"
+                rm=0
+            else
+                echo "Found RM of \${rm} in the ATNF catalogue"
+            fi
         fi
-    fi
-    pam --RM \${rm} -m ${meta.pulsar}_${meta.utc}_raw.scalP
-    if [ "\$raw_only" == "false" ]; then
-        pam --RM \${rm} -m ${meta.pulsar}_${meta.utc}_zap.scalP
-    fi
+        pam --RM \${rm} -m ${meta.pulsar}_${meta.utc}_raw.scalP
+        if [ "\$raw_only" == "false" ]; then
+            pam --RM \${rm} -m ${meta.pulsar}_${meta.utc}_zap.scalP
+        fi
 
-    if \$raw_only; then
-        echo "Delay correct"
-        dlyfix -e ar ${meta.pulsar}_${meta.utc}_raw.scalP
+        if \$raw_only; then
+            echo "Delay correct"
+            dlyfix -e ar ${meta.pulsar}_${meta.utc}_raw.scalP
 
-        echo "Flux calibrate"
-        # Create a time and polarisation scruchned profile
-        pam -Tp -e tp ${meta.pulsar}_${meta.utc}_raw.ar
-        fluxcal_meerkat \\
-            --psr_name ${meta.pulsar} \\
-            --obs_name ${meta.utc} \\
-            --obs_header ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/obs.header \\
-            --archive_file ${meta.pulsar}_${meta.utc}_raw.ar \\
-            --tp_file *tp \\
-            --par_file ${ephemeris}
+            echo "Flux calibrate"
+            # Create a time and polarisation scruchned profile
+            pam -Tp -e tp ${meta.pulsar}_${meta.utc}_raw.ar
+            fluxcal_meerkat \\
+                --psr_name ${meta.pulsar} \\
+                --obs_name ${meta.utc} \\
+                --obs_header ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/obs.header \\
+                --archive_file ${meta.pulsar}_${meta.utc}_raw.ar \\
+                --tp_file *tp \\
+                --par_file ${ephemeris}
 
-        echo "No template provided so there will be no cleaned archive"
-        touch ${meta.pulsar}_${meta.utc}_zap.ar
-        SNR=None
-        FLUX=None
+            echo "No template provided so there will be no cleaned archive"
+            touch ${meta.pulsar}_${meta.utc}_zap.ar
+            SNR=None
+            FLUX=None
+        else
+            echo "Delay correct"
+            dlyfix -e ar ${meta.pulsar}_${meta.utc}_zap.scalP
+
+            echo "Flux calibrate"
+            # Create a time and polarisation scruchned profile
+            pam -Tp -e tp ${meta.pulsar}_${meta.utc}_zap.ar
+            fluxcal_meerkat \\
+                --psr_name ${meta.pulsar} \\
+                --obs_name ${meta.utc} \\
+                --obs_header ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/obs.header \\
+                --archive_file ${meta.pulsar}_${meta.utc}_zap.ar \\
+                --tp_file *tp \\
+                --par_file ${ephemeris}
+
+            echo "Get the signal-to-noise ratio and flux density of the cleaned archive"
+            pam -FTp -e FTp ${meta.pulsar}_${meta.utc}_zap.ar
+            SNR=\$(psrstat -c snr=pdmp -c snr ${meta.pulsar}_${meta.utc}_zap.FTp | cut -d '=' -f 2)
+            FLUX=\$(pdv -f ${meta.pulsar}_${meta.utc}_zap.FTp | tail -n 1 | tr -s ' ' | cut -d ' ' -f 7)
+        fi
     else
-        echo "Delay correct"
-        dlyfix -e ar ${meta.pulsar}_${meta.utc}_zap.scalP
+        echo "The raw archive will not be refolded as it is not stored, creating a dummy raw file"
+        touch "${meta.pulsar}_${meta.utc}_raw_empty.ar"
+        echo "Refold the previously cleaned and flux calibrated archive"
+        pam -m -E ${ephemeris} ${cleaned_archive}
+        #the below is just in case the original cleaned archive didn't have the same naming convention
+        #first test if the cleaned archive is the same as the one in the directory
+        #the tr command removes the backslashes in the name but gives out a warning which is ignored
+        normalised_cleaned_archive=\$(echo "${cleaned_archive}" | tr -d '\\' 2>/dev/null )
+        normalised_expected_archive=\$(echo "${meta.pulsar}_${meta.utc}_zap.ar" | tr -d '\\' 2>/dev/null)
+        #echo \$normalised_cleaned_archive
+        #echo \$normalised_expected_archive
 
-        echo "Flux calibrate"
-        # Create a time and polarisation scruchned profile
-        pam -Tp -e tp ${meta.pulsar}_${meta.utc}_zap.ar
-        fluxcal_meerkat \\
-            --psr_name ${meta.pulsar} \\
-            --obs_name ${meta.utc} \\
-            --obs_header ${params.input_dir}/${meta.pulsar}/${meta.utc}/${meta.beam}/*/obs.header \\
-            --archive_file ${meta.pulsar}_${meta.utc}_zap.ar \\
-            --tp_file *tp \\
-            --par_file ${ephemeris}
+        if [ "\${normalised_cleaned_archive}" != "\${normalised_expected_archive}" ]; then
+            mv "${cleaned_archive}" "${meta.pulsar}_${meta.utc}_zap.ar"
+        fi
 
-        echo "Get the signal-to-noise ratio and flux density of the cleaned archive"
         pam -FTp -e FTp ${meta.pulsar}_${meta.utc}_zap.ar
         SNR=\$(psrstat -c snr=pdmp -c snr ${meta.pulsar}_${meta.utc}_zap.FTp | cut -d '=' -f 2)
         FLUX=\$(pdv -f ${meta.pulsar}_${meta.utc}_zap.FTp | tail -n 1 | tr -s ' ' | cut -d ' ' -f 7)

--- a/modules/local/psradd_calibrate_clean.nf
+++ b/modules/local/psradd_calibrate_clean.nf
@@ -162,7 +162,7 @@ process PSRADD_CALIBRATE_CLEAN {
         echo "The raw archive will not be refolded as it is not stored, creating a dummy raw file"
         touch "${meta.pulsar}_${meta.utc}_raw_empty.ar"
         echo "Refold the previously cleaned and flux calibrated archive"
-        pam -m -E ${ephemeris} ${cleaned_archive}
+        pam -m  --update_dm -E ${ephemeris} ${cleaned_archive}
         #the below is just in case the original cleaned archive didn't have the same naming convention
         #first test if the cleaned archive is the same as the one in the directory
         #the tr command removes the backslashes in the name but gives out a warning which is ignored

--- a/modules/local/upload_results.nf
+++ b/modules/local/upload_results.nf
@@ -62,16 +62,17 @@ process UPLOAD_RESULTS {
         # file_loc, file_type, file_res, cleaned
         image_data.append( (toa_file, type, 'high', True) )
 
-    # file_loc, file_type, file_res, cleaned
-    image_data.append( ("raw_profile_ftp.png",    'profile',     'high', False) )
-    image_data.append( ("raw_profile_fts.png",    'profile-pol', 'high', False) )
-    image_data.append( ("raw_phase_time.png",     'phase-time',  'high', False) )
-    image_data.append( ("raw_phase_freq.png",     'phase-freq',  'high', False) )
-    image_data.append( ("raw_bandpass.png",       'bandpass',    'high', False) )
-    image_data.append( ("raw_SNR_cumulative.png", 'snr-cumul',   'high', False) )
-    image_data.append( ("raw_SNR_single.png",     'snr-single',  'high', False) )
-    if os.path.exists("${meta.pulsar}_${meta.utc}_raw.ar.dynspec.png"):
-        image_data.append( ("${meta.pulsar}_${meta.utc}_raw.ar.dynspec.png", 'dynamic-spectrum', 'high', False) )
+    if [ "${params.refold_prev_ar}" == "false" ]:
+        # file_loc, file_type, file_res, cleaned
+        image_data.append( ("raw_profile_ftp.png",    'profile',     'high', False) )
+        image_data.append( ("raw_profile_fts.png",    'profile-pol', 'high', False) )
+        image_data.append( ("raw_phase_time.png",     'phase-time',  'high', False) )
+        image_data.append( ("raw_phase_freq.png",     'phase-freq',  'high', False) )
+        image_data.append( ("raw_bandpass.png",       'bandpass',    'high', False) )
+        image_data.append( ("raw_SNR_cumulative.png", 'snr-cumul',   'high', False) )
+        image_data.append( ("raw_SNR_single.png",     'snr-single',  'high', False) )
+        if os.path.exists("${meta.pulsar}_${meta.utc}_raw.ar.dynspec.png"):
+            image_data.append( ("${meta.pulsar}_${meta.utc}_raw.ar.dynspec.png", 'dynamic-spectrum', 'high', False) )
     if not raw_only:
         image_data.append( ("cleaned_profile_ftp.png",    'profile',     'high', True ) )
         image_data.append( ("cleaned_profile_fts.png",    'profile-pol', 'high', True ) )

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,6 +36,7 @@ params {
 
     // Processing options
     use_prev_ar = false // If true grab a previous archive file from output directory
+    refold_prev_ar = false // If true refold the previously created cleaned and flux calibrated archive file from output directory. The raw archive and plots will not be re-made.
     use_edge_subints = false // Use first and last 8 second subints of observation archives
     use_max_nsub = true // Use the maximum number of subints possible for the observation based on the S/N ratio
     use_all_nsub = true // Use the all nsubs, do not time scrunch
@@ -146,7 +147,7 @@ def mem_calc(factor, task_attempt, nchan, nbin, dur, ram_max) {
 
 // Software versions
 psrdb_version = "3.0.6"
-meerpipe_version = "71bd66c"
+meerpipe_version = "6673ef9"
 tempo2_version = "ce14d72_temponest_apar_56e2b58"
 tempo2_clock_version = "2021-04-26"
 psrchive_version = "4c0597b7b"
@@ -255,7 +256,7 @@ if ( hostname.startsWith("tooarrana") || hostname.startsWith("trevor") ) {
 
 }
 else if ( hostname.startsWith("farnarkle") ) {
-    // Set up for Swinburnes's Ozstar cluster
+    // TO DO if there is a use case. Currently only set up to run on NT - Tooarrana nodes.
 }
 else {
     // No recognised hostname so assuming defaults

--- a/nextflow.config
+++ b/nextflow.config
@@ -146,12 +146,12 @@ def mem_calc(factor, task_attempt, nchan, nbin, dur, ram_max) {
 }
 
 // Software versions
-psrdb_version = "3.0.6"
-meerpipe_version = "6673ef9"
+psrdb_version = "f504932"
+meerpipe_version = "71bd66c"
 tempo2_version = "ce14d72_temponest_apar_56e2b58"
 tempo2_clock_version = "2021-04-26"
 psrchive_version = "4c0597b7b"
-meertime_ephemerides_and_templates_version = "33d7e38"
+meertime_ephemerides_and_templates_version = "a735595"
 
 
 // CLUSTER SPECFIC DEFAULTS

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -94,6 +94,11 @@
                     "fa_icon": "fas fa-angle-double-left",
                     "description": "Use the previously created calibrated and cleaned archive in the output directory."
                 },
+                "refold_prev_ar": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-angle-double-left",
+                    "description": "Refold the previously created calibrated and cleaned archive in the output directory. The raw archive and plots will not be re-made."
+                },
                 "use_edge_subints": {
                     "type": "boolean",
                     "description": "Use first and last 8 second subints of observation archives.",
@@ -131,7 +136,7 @@
                 },
                 "nchans": {
                     "type": "string",
-                    "default": "1,8,16,32,928",
+                    "default": "1,16,32,58,116,928",
                     "description": "Comma separated list of nchans to frequency scrunch the data into",
                     "fa_icon": "fas fa-align-justify"
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -136,7 +136,7 @@
                 },
                 "nchans": {
                     "type": "string",
-                    "default": "1,16,32,58,116,928",
+                    "default": "1,8,16,32,928",
                     "description": "Comma separated list of nchans to frequency scrunch the data into",
                     "fa_icon": "fas fa-align-justify"
                 },

--- a/workflows/meerpipe.nf
+++ b/workflows/meerpipe.nf
@@ -46,7 +46,10 @@ workflow MEERPIPE {
         error "If you provide an ephemeris, you must also provide a project with --project"
     }
     if ( params.template != "" && params.project == "" ) {
-        error "If you provide an template, you must also provide a project with --project"
+        error "If you provide a template, you must also provide a project with --project"
+    }
+    if ( params.use_prev_ar == true && params.refold_prev_ar == true ) {
+        error "You cannot use both --use_prev_ar and --refold_prev_ar"
     }
 
     // Use PSRDB to work out which obs to process
@@ -65,7 +68,7 @@ workflow MEERPIPE {
     )
 
     if ( params.use_prev_ar) {
-        // Covert csv into a tupe of the meta map and the files
+        // Convert csv into a tupe of the meta map and the files
         files_and_meta = OBS_LIST.out.splitCsv()
         .map {
             pulsar, utc, project_short, beam, band, dur, mode_dur, obs_nchan, obs_nbin, cal_loc, pipe_id, ephemeris, template, n_obs, snr, flux, percent_rfi_zapped, raw_archive, cleaned_archive ->
@@ -95,11 +98,42 @@ workflow MEERPIPE {
                 file(cleaned_archive),
             ]
         }
-    } else {
-        // Covert csv into a tupe of the meta map and the files
+    } else if ( params.refold_prev_ar ) {
+        // Convert csv into a tuple of the meta map and the files
         obs_data = OBS_LIST.out.splitCsv()
         .map {
-            pulsar, utc, project_short, beam, band, dur, mode_dur, obs_nchan, obs_nbin, cal_loc, pipe_id, ephemeris, template, n_obs ->
+            pulsar, utc, project_short, beam, band, dur, mode_dur, obs_nchan, obs_nbin, cal_loc, pipe_id, ephemeris, template, n_obs, percent_rfi_zapped, raw_archive, cleaned_archive ->
+            [
+                [
+                    id: "${pulsar}_${utc}_${beam}",
+                    pulsar: pulsar,
+                    utc: utc,
+                    beam: beam,
+                    project_short: project_short,
+                    band: band,
+                    dur: dur,
+                    mode_dur: mode_dur,
+                    obs_nchan: obs_nchan,
+                    obs_nbin: obs_nbin,
+                    pipe_id: pipe_id,
+                    nchans: params.nchans.split(',').collect { it.toInteger() },
+                    npols:params.npols.split(',').collect  { it.toInteger() },
+                    n_obs: n_obs,
+                    percent_rfi_zapped: percent_rfi_zapped,
+                ],
+                file(cal_loc), 
+                file(ephemeris),
+                file(template),
+                file(raw_archive),
+                file(cleaned_archive),
+            ]
+        }
+    } else {
+        // This is if refold prev ar and use prev ar are both false
+        // Convert csv into a tuple of the meta map and the files
+        obs_data = OBS_LIST.out.splitCsv()
+        .map {
+            pulsar, utc, project_short, beam, band, dur, mode_dur, obs_nchan, obs_nbin, cal_loc, pipe_id, ephemeris, template, n_obs, raw_archive, cleaned_archive ->
             [
                 [
                     id: "${pulsar}_${utc}_${beam}",
@@ -117,13 +151,18 @@ workflow MEERPIPE {
                     npols:params.npols.split(',').collect  { it.toInteger() },
                     n_obs: n_obs,
                 ],
-                cal_loc,
-                ephemeris,
-                template,
+                file(cal_loc),
+                file(ephemeris),
+                file(template),
+                file(raw_archive), 
+                file(cleaned_archive) // This is here passed as empty_clean.ar 
             ]
         }
+    }
 
+    if (params.use_prev_ar == false) {
         // Combine archives,flux calibrate Clean of RFI with MeerGaurd
+        // obs_data is not defined if use_prev_ar is true so this will not run if use_prev_ar is true
         PSRADD_CALIBRATE_CLEAN( obs_data )
 
         files_and_meta = PSRADD_CALIBRATE_CLEAN.out
@@ -149,14 +188,15 @@ workflow MEERPIPE {
                         snr: snr,
                         flux: flux,
                     ],
-                    ephemeris,
-                    template,
-                    raw_archive,
-                    cleaned_archive,
+                    file(ephemeris),
+                    file(template),
+                    file(raw_archive),
+                    file(cleaned_archive),
                 ]
             }
 
         // Calculate the DM with tempo2 or pdmp
+        // This is run on the cleaned archive and does not require a raw archive though it is passed through for the next step. It will also run if use_prev_ar or refold_prev_ar are true.
         DM_RM_CALC( files_and_meta )
 
         // Other images using matplotlib and psrplot and make a results.json


### PR DESCRIPTION
Hi Nick, I have added an option to refold the previously psradded/cleaned/calibrated archive.
It gets the RFI zapping fraction from that previous archive but re-calculates S/N and flux post refolding.
This will skip making raw data plots and uploading them.

It would be great if you could give it a check please :)

A small extra is that the pipeline will check for the existence of the raw/clean archives at the obs_list stage, before using them , instead of failing later on.

I have also updated OzGrav/meerpipe to only make the clean archive plots in the case of refold.

I have done the nf-tests and also tested a bunch of pipeline run cases, all behaving as expected:
- regular run
- regular re-run
- raw archive available only and no template
- same as above with template
- no previous runs and no template
- use prev ar and no cleaned data available
- use prev ar normal case
- refold with available cleaned data
- refold with no available cleaned data
- refold with available cleaned data but no template