### PR TITLE
Attempt to allow more CPUs for high memory jobs

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -171,7 +171,7 @@ if ( hostname.startsWith("tooarrana") || hostname.startsWith("trevor") ) {
 
     // Max resources for the milan partition
     params {
-        max_memory                 = '100.GB'
+        max_memory                 = '100.GB' // This is a per-CPU limit introduced in June 2025
         max_cpus                   = 62
         max_time                   = '7.day'
     }
@@ -223,9 +223,9 @@ if ( hostname.startsWith("tooarrana") || hostname.startsWith("trevor") ) {
             errorStrategy = 'retry'
             maxRetries = 2
             queue  = 'milan'
-            cpus   = 1
             time   = { "${task.attempt * 1.5 * meta.dur.toFloat() * meta.obs_nchan.toFloat()/1024 + 300} s" }
             memory = { "${mem_calc(9, task.attempt, meta.obs_nchan, meta.obs_nbin, meta.dur, params.max_memory)} GB" }
+            cpus = { Math.max(1, Math.ceil(memory.toGiga() / (params.max_memory as nextflow.util.MemoryUnit).toGiga()) as int) }
         }
         withLabel: scratch {
             scratch = '$JOBFS'


### PR DESCRIPTION
This is because in June 2025 was introduced a per CPU memory limit of 100 Gb. Some jobs reach this limit in the memory calculation. Even though the job are low CPU, if we give them two CPUs with 100Gb each the job will not fail with OOM

<!--
# nf-core/meerpipe pull request

Many thanks for contributing to nf-core/meerpipe!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/meerpipe/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/meerpipe/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/meerpipe _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
